### PR TITLE
Access token cache rebased

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.2
       - uses: engineerd/configurator@v0.0.10
         with:
           name: just
@@ -30,7 +30,7 @@ jobs:
         # but bash does!
         shell: bash
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.2
       - uses: engineerd/configurator@v0.0.10
         with:
           name: just
@@ -50,7 +50,7 @@ jobs:
           - advisories
           - bans licenses sources
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.2
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - uses: engineerd/configurator@v0.0.10
         with:
           name: just
@@ -30,7 +30,7 @@ jobs:
         # but bash does!
         shell: bash
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - uses: engineerd/configurator@v0.0.10
         with:
           name: just
@@ -50,7 +50,7 @@ jobs:
           - advisories
           - bans licenses sources
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/daily_security.yml
+++ b/.github/workflows/daily_security.yml
@@ -8,7 +8,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily_security.yml
+++ b/.github/workflows/daily_security.yml
@@ -8,7 +8,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,6 @@ jobs:
     name: publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.2
       - name: publish oci-distribution to crates.io
         run: cargo publish --token ${{ secrets.CargoToken }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,6 @@ jobs:
     name: publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: publish oci-distribution to crates.io
         run: cargo publish --token ${{ secrets.CargoToken }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.11.0"
+version = "0.10.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,6 @@ docker_credential = "1.0"
 hmac = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3.3"
-testcontainers = "0.14"
+testcontainers = "0.15"
 tokio = { version = "1.21", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,15 @@ authors = [
 ]
 description = "An OCI implementation in Rust"
 edition = "2021"
-keywords = [
-  "oci",
-  "containers",
-]
+keywords = ["oci", "containers"]
 license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.10.0"
+version = "0.11.0"
 
 [badges]
-maintenance = {status = "actively-developed"}
+maintenance = { status = "actively-developed" }
 
 [features]
 default = ["native-tls", "test-registry"]
@@ -44,7 +41,10 @@ jwt = "0.16"
 lazy_static = "1.4"
 olpc-cjson = "0.1"
 regex = "1.6"
-reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "json",
+  "stream",
+] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,13 @@ test-registry = []
 bytes = "1"
 chrono = { version = "0.4.23", features = ["serde"] }
 futures-util = "0.3"
-http = "0.2"
+http = "1.1"
 http-auth = { version = "0.1", default_features = false }
 jwt = "0.16"
 lazy_static = "1.4"
 olpc-cjson = "0.1"
 regex = "1.6"
-reqwest = { version = "0.11", default-features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "stream",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 name = "oci-distribution"
 readme = "README.md"
 repository = "https://github.com/krustlet/oci-distribution"
-version = "0.10.0"
+version = "0.11.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/examples/get-manifest/main.rs
+++ b/examples/get-manifest/main.rs
@@ -34,7 +34,7 @@ pub(crate) struct Cli {
 fn build_auth(reference: &Reference, cli: &Cli) -> RegistryAuth {
     let server = reference
         .resolve_registry()
-        .strip_suffix("/")
+        .strip_suffix('/')
         .unwrap_or_else(|| reference.resolve_registry());
 
     if cli.anonymous {
@@ -85,7 +85,7 @@ pub async fn main() {
     let auth = build_auth(&reference, &cli);
 
     let client_config = build_client_config(&cli);
-    let mut client = Client::new(client_config);
+    let client = Client::new(client_config);
 
     let (manifest, _) = client
         .pull_manifest(&reference, &auth)

--- a/examples/get-manifest/main.rs
+++ b/examples/get-manifest/main.rs
@@ -85,7 +85,7 @@ pub async fn main() {
     let auth = build_auth(&reference, &cli);
 
     let client_config = build_client_config(&cli);
-    let mut client = Client::new(client_config);
+    let client = Client::new(client_config);
 
     let (manifest, _) = client
         .pull_manifest(&reference, &auth)

--- a/examples/wasm/main.rs
+++ b/examples/wasm/main.rs
@@ -19,7 +19,7 @@ use push::push_wasm;
 fn build_auth(reference: &Reference, cli: &Cli) -> RegistryAuth {
     let server = reference
         .resolve_registry()
-        .strip_suffix("/")
+        .strip_suffix('/')
         .unwrap_or_else(|| reference.resolve_registry());
 
     if cli.anonymous {
@@ -73,7 +73,7 @@ pub async fn main() {
         crate::cli::Commands::Pull { output, image } => {
             let reference: Reference = image.parse().expect("Not a valid image reference");
             let auth = build_auth(&reference, &cli);
-            pull_wasm(&mut client, &auth, &reference, &output).await;
+            pull_wasm(&mut client, &auth, &reference, output).await;
         }
         crate::cli::Commands::Push {
             module,
@@ -98,17 +98,14 @@ pub async fn main() {
                         values.insert(String::from(tmp[0]), String::from(tmp[1]));
                     }
                 }
-                if !values.contains_key(&annotations::ORG_OPENCONTAINERS_IMAGE_TITLE.to_string()) {
-                    values.insert(
-                        annotations::ORG_OPENCONTAINERS_IMAGE_TITLE.to_string(),
-                        module.clone(),
-                    );
-                }
+                values
+                    .entry(annotations::ORG_OPENCONTAINERS_IMAGE_TITLE.to_string())
+                    .or_insert_with(|| module.clone());
 
                 Some(values)
             };
 
-            push_wasm(&mut client, &auth, &reference, &module, annotations).await;
+            push_wasm(&mut client, &auth, &reference, module, annotations).await;
         }
     }
 }

--- a/examples/wasm/push.rs
+++ b/examples/wasm/push.rs
@@ -35,7 +35,7 @@ pub(crate) async fn push_wasm(
     let image_manifest = manifest::OciImageManifest::build(&layers, &config, annotations);
 
     let response = client
-        .push(&reference, &layers, config, &auth, Some(image_manifest))
+        .push(reference, &layers, config, auth, Some(image_manifest))
         .await
         .map(|push_response| push_response.manifest_url)
         .expect("Cannot push Wasm module");

--- a/src/client.rs
+++ b/src/client.rs
@@ -364,7 +364,7 @@ impl Client {
 
         validate_registry_response(status, &body, &url)?;
 
-        Ok(serde_json::from_str(&std::str::from_utf8(&body)?)?)
+        Ok(serde_json::from_str(std::str::from_utf8(&body)?)?)
     }
 
     /// Pull an image and return the bytes
@@ -856,10 +856,10 @@ impl Client {
 
         let text = std::str::from_utf8(&body)?;
 
-        self.validate_image_manifest(&text).await?;
+        self.validate_image_manifest(text).await?;
 
         debug!("Parsing response as Manifest: {}", &text);
-        let manifest = serde_json::from_str(&text)
+        let manifest = serde_json::from_str(text)
             .map_err(|e| OciDistributionError::ManifestParsingError(e.to_string()))?;
         Ok((manifest, digest))
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -534,6 +534,8 @@ impl Client {
         authentication: &RegistryAuth,
         operation: RegistryOperation,
     ) -> Result<Option<String>> {
+        self.store_auth_if_needed(image.resolve_registry(), authentication)
+            .await;
         // preserve old caching behavior
         match self._auth(image, authentication, operation).await {
             Ok(Some(RegistryTokenType::Bearer(token))) => {
@@ -1801,6 +1803,14 @@ mod test {
             .sign_with_key(&key)?
             .as_str()
             .to_string();
+
+        // we have to have it in the stored auth so we'll get to the token cache check.
+        client
+            .store_auth(
+                &Reference::try_from(HELLO_IMAGE_TAG)?.resolve_registry(),
+                RegistryAuth::Anonymous,
+            )
+            .await;
 
         client
             .tokens

--- a/src/client.rs
+++ b/src/client.rs
@@ -2641,7 +2641,7 @@ mod test {
     async fn test_platform_resolution() {
         // test that we get an error when we pull a manifest list
         let reference = Reference::try_from(DOCKER_IO_IMAGE).expect("failed to parse reference");
-        let c = Client::new(ClientConfig {
+        let mut c = Client::new(ClientConfig {
             platform_resolver: None,
             ..Default::default()
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -301,13 +301,13 @@ impl Client {
         }
 
         let request = self.client.get(&url);
-        let request = if n.is_some() {
-            request.query(&[("n", n.unwrap())])
+        let request = if let Some(num) = n {
+            request.query(&[("n", num)])
         } else {
             request
         };
-        let request = if last.is_some() {
-            request.query(&[("last", last.unwrap())])
+        let request = if let Some(l) = last {
+            request.query(&[("last", l)])
         } else {
             request
         };

--- a/src/client.rs
+++ b/src/client.rs
@@ -736,8 +736,8 @@ impl Client {
     /// The client will check if it's already been authenticated and if
     /// not will attempt to do.
     ///
-    /// A Tuple is returned containing the plain text representation of the manifest
-    /// and the manifest content digest hash.
+    /// A Tuple is returned containing raw byte representation of the manifest
+    /// and the manifest content digest.
     pub async fn pull_manifest_raw(
         &self,
         image: &Reference,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1939,7 +1939,7 @@ mod test {
     #[test]
     fn can_generate_valid_digest() {
         let bytes = b"hellobytes";
-        let hash = sha256_digest(&bytes.to_vec());
+        let hash = sha256_digest(bytes);
 
         let combination = vec![b"hello".to_vec(), b"bytes".to_vec()];
         let combination_hash =

--- a/src/client.rs
+++ b/src/client.rs
@@ -2762,7 +2762,7 @@ mod test {
     #[tokio::test]
     async fn test_raw_manifest_digest() {
         let _ = tracing_subscriber::fmt::try_init();
-        
+
         let c = Client::default();
 
         // pulling webassembly.azurecr.io/hello-wasm:v1@sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7

--- a/src/client.rs
+++ b/src/client.rs
@@ -360,11 +360,11 @@ impl Client {
             .send()
             .await?;
         let status = res.status();
-        let text = res.text().await?;
+        let body = res.bytes().await?;
 
-        validate_registry_response(status, &text, &url)?;
+        validate_registry_response(status, &body, &url)?;
 
-        Ok(serde_json::from_str(&text)?)
+        Ok(serde_json::from_str(&std::str::from_utf8(&body)?)?)
     }
 
     /// Pull an image and return the bytes
@@ -676,15 +676,15 @@ impl Client {
             let status = res.status();
             let headers = res.headers().clone();
             trace!(headers=?res.headers(), "Got Headers");
-            let text = res.text().await?;
-            validate_registry_response(status, &text, &url)?;
+            let body = res.bytes().await?;
+            validate_registry_response(status, &body, &url)?;
 
-            digest_header_value(headers, Some(&text.as_bytes()))
+            digest_header_value(headers, Some(&body))
         } else {
             let status = res.status();
             let headers = res.headers().clone();
-            let text = res.text().await?;
-            validate_registry_response(status, &text, &url)?;
+            let body = res.bytes().await?;
+            validate_registry_response(status, &body, &url)?;
 
             digest_header_value(headers, None)
         }
@@ -743,7 +743,7 @@ impl Client {
         image: &Reference,
         auth: &RegistryAuth,
         accepted_media_types: &[&str],
-    ) -> Result<(String, String)> {
+    ) -> Result<(Vec<u8>, String)> {
         self.store_auth_if_needed(image.resolve_registry(), auth)
             .await;
 
@@ -823,7 +823,7 @@ impl Client {
         &self,
         image: &Reference,
         accepted_media_types: &[&str],
-    ) -> Result<(String, String)> {
+    ) -> Result<(Vec<u8>, String)> {
         let url = self.to_v2_manifest_url(image);
         debug!("Pulling image manifest from {}", url);
 
@@ -836,13 +836,13 @@ impl Client {
             .await?;
         let headers = res.headers().clone();
         let status = res.status();
-        let text = res.text().await?;
+        let body = res.bytes().await?;
 
-        validate_registry_response(status, &text, &url)?;
+        validate_registry_response(status, &body, &url)?;
 
-        let digest = digest_header_value(headers, Some(&text.as_bytes()))?;
+        let digest = digest_header_value(headers, Some(&body))?;
 
-        Ok((text, digest))
+        Ok((body.to_vec(), digest))
     }
 
     /// Pull a manifest from the remote OCI Distribution service.
@@ -850,9 +850,11 @@ impl Client {
     /// If the connection has already gone through authentication, this will
     /// use the bearer token. Otherwise, this will attempt an anonymous pull.
     async fn _pull_manifest(&self, image: &Reference) -> Result<(OciManifest, String)> {
-        let (text, digest) = self
+        let (body, digest) = self
             ._pull_manifest_raw(image, MIME_TYPES_DISTRIBUTION_MANIFEST)
             .await?;
+
+        let text = std::str::from_utf8(&body)?;
 
         self.validate_image_manifest(&text).await?;
 
@@ -1414,7 +1416,7 @@ impl Client {
 /// The OCI spec technically does not allow any codes but 200, 500, 401, and 404.
 /// Obviously, HTTP servers are going to send other codes. This tries to catch the
 /// obvious ones (200, 4XX, 5XX). Anything else is just treated as an error.
-fn validate_registry_response(status: reqwest::StatusCode, text: &str, url: &str) -> Result<()> {
+fn validate_registry_response(status: reqwest::StatusCode, body: &[u8], url: &str) -> Result<()> {
     match status {
         reqwest::StatusCode::OK => Ok(()),
         reqwest::StatusCode::UNAUTHORIZED => Err(OciDistributionError::UnauthorizedError {
@@ -1426,6 +1428,7 @@ fn validate_registry_response(status: reqwest::StatusCode, text: &str, url: &str
             status,
         ))),
         s if s.is_client_error() => {
+            let text = std::str::from_utf8(body)?;
             // According to the OCI spec, we should see an error in the message body.
             let envelope = serde_json::from_str::<OciEnvelope>(text)?;
             Err(OciDistributionError::RegistryError {
@@ -1433,11 +1436,15 @@ fn validate_registry_response(status: reqwest::StatusCode, text: &str, url: &str
                 url: url.to_string(),
             })
         }
-        s => Err(OciDistributionError::ServerError {
-            code: s.as_u16(),
-            url: url.to_string(),
-            message: text.to_string(),
-        }),
+        s => {
+            let text = std::str::from_utf8(body)?;
+
+            Err(OciDistributionError::ServerError {
+                code: s.as_u16(),
+                url: url.to_string(),
+                message: text.to_string(),
+            })
+        }
     }
 }
 
@@ -2753,18 +2760,10 @@ mod test {
     }
 
     #[tokio::test]
-    #[cfg(feature = "test-registry")]
     async fn test_raw_manifest_digest() {
-        let docker = clients::Cli::default();
-        let test_container = docker.run(registry_image());
-
         let _ = tracing_subscriber::fmt::try_init();
-        let port = test_container.get_host_port_ipv4(5000);
-
-        let c = Client::new(ClientConfig {
-            protocol: ClientProtocol::HttpsExcept(vec![format!("localhost:{}", port)]),
-            ..Default::default()
-        });
+        
+        let c = Client::default();
 
         // pulling webassembly.azurecr.io/hello-wasm:v1@sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7
         let image: Reference = HELLO_IMAGE_TAG_AND_DIGEST.parse().unwrap();
@@ -2782,7 +2781,7 @@ mod test {
             .expect("failed to pull manifest");
 
         // Compute the digest of the returned manifest text.
-        let digest = sha2::Sha256::digest(manifest.as_bytes());
+        let digest = sha2::Sha256::digest(manifest);
         let hex = format!("sha256:{:x}", digest);
 
         // Validate that the computed digest and the digest in the pulled reference match.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1651,11 +1651,7 @@ mod test {
     use tokio_util::io::StreamReader;
 
     #[cfg(feature = "test-registry")]
-    use testcontainers::{
-        clients,
-        core::WaitFor,
-        images::{self, generic::GenericImage},
-    };
+    use testcontainers::{clients, core::WaitFor, GenericImage};
 
     const HELLO_IMAGE_NO_TAG: &str = "webassembly.azurecr.io/hello-wasm";
     const HELLO_IMAGE_TAG: &str = "webassembly.azurecr.io/hello-wasm:v1";
@@ -2362,19 +2358,19 @@ mod test {
     // We require this fix only when testing the capability to list tags
     #[cfg(feature = "test-registry")]
     fn registry_image_edge() -> GenericImage {
-        images::generic::GenericImage::new("distribution/distribution", "edge")
+        GenericImage::new("distribution/distribution", "edge")
             .with_wait_for(WaitFor::message_on_stderr("listening on "))
     }
 
     #[cfg(feature = "test-registry")]
     fn registry_image() -> GenericImage {
-        images::generic::GenericImage::new("docker.io/library/registry", "2")
+        GenericImage::new("docker.io/library/registry", "2")
             .with_wait_for(WaitFor::message_on_stderr("listening on "))
     }
 
     #[cfg(feature = "test-registry")]
     fn registry_image_basic_auth(auth_path: &str) -> GenericImage {
-        images::generic::GenericImage::new("docker.io/library/registry", "2")
+        GenericImage::new("docker.io/library/registry", "2")
             .with_env_var("REGISTRY_AUTH", "htpasswd")
             .with_env_var("REGISTRY_AUTH_HTPASSWD_REALM", "Registry Realm")
             .with_env_var("REGISTRY_AUTH_HTPASSWD_PATH", "/auth/htpasswd")

--- a/src/client.rs
+++ b/src/client.rs
@@ -208,7 +208,8 @@ pub struct Client {
     config: Arc<ClientConfig>,
     // Registry -> RegistryAuth
     auth_store: Arc<RwLock<HashMap<String, RegistryAuth>>>,
-    tokens: TokenCache,
+    /// TODO: Hack.
+    pub tokens: TokenCache,
     client: reqwest::Client,
     push_chunk_size: usize,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -309,7 +309,7 @@ pub struct History {
 #[cfg(test)]
 mod tests {
     use assert_json_diff::assert_json_eq;
-    use chrono::{TimeZone, Utc};
+    use chrono::DateTime;
     use rstest::*;
     use serde_json::Value;
     use std::collections::{HashMap, HashSet};
@@ -411,14 +411,14 @@ mod tests {
         };
 
         let history = Some(vec![History {
-            created: Some(Utc.datetime_from_str("2015-10-31T22:22:54.690851953Z", "%+").expect("parse time failed")),
+            created: Some(DateTime::parse_from_rfc3339("2015-10-31T22:22:54.690851953Z").expect("parse time failed").into()),
             author: None,
             created_by: Some("/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /".into()),
             comment: None,
             empty_layer: None,
         },
         History {
-            created: Some(Utc.datetime_from_str("2015-10-31T22:22:55.613815829Z", "%+").expect("parse time failed")),
+            created: Some(DateTime::parse_from_rfc3339("2015-10-31T22:22:55.613815829Z").expect("parse time failed").into()),
             author: None,
             created_by: Some("/bin/sh -c #(nop) CMD [\"sh\"]".into()),
             comment: None,
@@ -426,8 +426,9 @@ mod tests {
         }]);
         ConfigFile {
             created: Some(
-                Utc.datetime_from_str("2015-10-31T22:22:56.015925234Z", "%+")
-                    .expect("parse time failed"),
+                DateTime::parse_from_rfc3339("2015-10-31T22:22:56.015925234Z")
+                    .expect("parse time failed")
+                    .into(),
             ),
             author: Some("Alyssa P. Hacker <alyspdev@example.com>".into()),
             architecture: Architecture::Amd64,
@@ -503,8 +504,9 @@ mod tests {
         });
         let history = Some(vec![History {
             created: Some(
-                Utc.datetime_from_str("2023-04-21T11:53:28.176613804Z", "%+")
-                    .expect("parse time failed"),
+                DateTime::parse_from_rfc3339("2023-04-21T11:53:28.176613804Z")
+                    .expect("parse time failed")
+                    .into(),
             ),
             author: None,
             created_by: Some("COPY ./src/main.rs / # buildkit".into()),
@@ -526,8 +528,9 @@ mod tests {
             rootfs,
             history,
             created: Some(
-                Utc.datetime_from_str("2023-04-21T11:53:28.176613804Z", "%+")
-                    .expect("parse time failed"),
+                DateTime::parse_from_rfc3339("2023-04-21T11:53:28.176613804Z")
+                    .expect("parse time failed")
+                    .into(),
             ),
             author: None,
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,9 @@ pub enum OciDistributionError {
     #[error(transparent)]
     /// Transparent wrapper around `serde_json::error::Error`
     JsonError(#[from] serde_json::error::Error),
+    /// Manifest is not valid UTF-8
+    #[error("Manifest is not valid UTF-8")]
+    ManifestEncodingError(#[from] std::str::Utf8Error),
     /// Manifest: JSON unmarshalling error
     #[error("Failed to parse manifest as Versioned object: {0}")]
     ManifestParsingError(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod manifest;
 mod reference;
 mod regexp;
 pub mod secrets;
-mod token_cache;
+pub mod token_cache;
 
 #[doc(inline)]
 pub use client::Client;

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -59,7 +59,15 @@ pub enum RegistryOperation {
     Pull,
 }
 
-type CacheType = BTreeMap<(String, String, RegistryOperation), (RegistryTokenType, u64)>;
+// Types to allow better naming
+type Registry = String;
+type Repository = String;
+type TokenCacheKey = (Registry, Repository, RegistryOperation);
+type TokenExpiration = u64;
+type TokenCacheValue = (RegistryTokenType, TokenExpiration);
+
+// (registry, repository, scope) -> (token, expiration)
+type CacheType = BTreeMap<TokenCacheKey, TokenCacheValue>;
 
 #[derive(Default, Clone)]
 pub(crate) struct TokenCache {
@@ -68,12 +76,6 @@ pub(crate) struct TokenCache {
 }
 
 impl TokenCache {
-    pub(crate) fn new() -> Self {
-        TokenCache {
-            tokens: Arc::new(RwLock::new(BTreeMap::new())),
-        }
-    }
-
     pub(crate) async fn insert(
         &self,
         reference: &Reference,
@@ -157,9 +159,5 @@ impl TokenCache {
                 None
             }
         }
-    }
-
-    pub(crate) async fn contains_key(&self, reference: &Reference, op: RegistryOperation) -> bool {
-        self.get(reference, op).await.is_some()
     }
 }

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -2,7 +2,9 @@ use crate::reference::Reference;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fmt;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
 /// A token granted during the OAuth2-like workflow for OCI registries.
@@ -29,7 +31,7 @@ impl fmt::Debug for RegistryToken {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum RegistryTokenType {
     Bearer(RegistryToken),
     Basic(String, String),
@@ -57,20 +59,22 @@ pub enum RegistryOperation {
     Pull,
 }
 
-#[derive(Default)]
+type CacheType = BTreeMap<(String, String, RegistryOperation), (RegistryTokenType, u64)>;
+
+#[derive(Default, Clone)]
 pub(crate) struct TokenCache {
     // (registry, repository, scope) -> (token, expiration)
-    tokens: BTreeMap<(String, String, RegistryOperation), (RegistryTokenType, u64)>,
+    tokens: Arc<RwLock<CacheType>>,
 }
 
 impl TokenCache {
     pub(crate) fn new() -> Self {
         TokenCache {
-            tokens: BTreeMap::new(),
+            tokens: Arc::new(RwLock::new(BTreeMap::new())),
         }
     }
 
-    pub(crate) fn insert(
+    pub(crate) async fn insert(
         &mut self,
         reference: &Reference,
         op: RegistryOperation,
@@ -116,17 +120,24 @@ impl TokenCache {
         let repository = reference.repository().to_string();
         debug!(%registry, %repository, ?op, %expiration, "Inserting token");
         self.tokens
+            .write()
+            .await
             .insert((registry, repository, op), (token, expiration));
     }
 
-    pub(crate) fn get(
+    pub(crate) async fn get(
         &self,
         reference: &Reference,
         op: RegistryOperation,
-    ) -> Option<&RegistryTokenType> {
+    ) -> Option<RegistryTokenType> {
         let registry = reference.resolve_registry().to_string();
         let repository = reference.repository().to_string();
-        match self.tokens.get(&(registry.clone(), repository.clone(), op)) {
+        match self
+            .tokens
+            .read()
+            .await
+            .get(&(registry.clone(), repository.clone(), op))
+        {
             Some((ref token, expiration)) => {
                 let now = SystemTime::now();
                 let epoch = now
@@ -138,7 +149,7 @@ impl TokenCache {
                     None
                 } else {
                     debug!(%registry, %repository, ?op, %expiration, miss=false, expired=false, "Fetching token");
-                    Some(token)
+                    Some(token.clone())
                 }
             }
             None => {
@@ -148,7 +159,7 @@ impl TokenCache {
         }
     }
 
-    pub(crate) fn contains_key(&self, reference: &Reference, op: RegistryOperation) -> bool {
-        self.get(reference, op).is_some()
+    pub(crate) async fn contains_key(&self, reference: &Reference, op: RegistryOperation) -> bool {
+        self.get(reference, op).await.is_some()
     }
 }

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -75,7 +75,7 @@ impl TokenCache {
     }
 
     pub(crate) async fn insert(
-        &mut self,
+        &self,
         reference: &Reference,
         op: RegistryOperation,
         token: RegistryTokenType,

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -1,3 +1,5 @@
+//! Types for working with registry auth tokens
+
 use crate::reference::Reference;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -11,9 +13,17 @@ use tracing::{debug, warn};
 #[derive(Deserialize, Clone)]
 #[serde(untagged)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum RegistryToken {
-    Token { token: String },
-    AccessToken { access_token: String },
+pub enum RegistryToken {
+    /// Token value
+    Token {
+        /// The string value of the token
+        token: String,
+    },
+    /// AccessToken value
+    AccessToken {
+        /// The string value of the access_token
+        access_token: String,
+    },
 }
 
 impl fmt::Debug for RegistryToken {
@@ -31,17 +41,21 @@ impl fmt::Debug for RegistryToken {
     }
 }
 
+/// Type of registry auth token
 #[derive(Debug, Clone)]
-pub(crate) enum RegistryTokenType {
+pub enum RegistryTokenType {
+    /// Bearer token type
     Bearer(RegistryToken),
+    /// Basic auth token type
     Basic(String, String),
 }
 
 impl RegistryToken {
+    /// Returns the bearer token in a form suitable to use for an Authorization header
     pub fn bearer_token(&self) -> String {
         format!("Bearer {}", self.token())
     }
-
+    /// Returns the token value
     pub fn token(&self) -> &str {
         match self {
             RegistryToken::Token { token } => token,
@@ -72,13 +86,15 @@ struct TokenCacheValue {
 }
 
 #[derive(Default, Clone)]
-pub(crate) struct TokenCache {
+/// A cache to hold authentication tokens
+pub struct TokenCache {
     // (registry, repository, scope) -> (token, expiration)
     tokens: Arc<RwLock<BTreeMap<TokenCacheKey, TokenCacheValue>>>,
 }
 
 impl TokenCache {
-    pub(crate) async fn insert(
+    /// Insert a token corresponding to reference and operation keys
+    pub async fn insert(
         &self,
         reference: &Reference,
         op: RegistryOperation,


### PR DESCRIPTION
Pulling in upstream changes from krustlet/oci-distribution@main into the access-token-cache branch

The changes related to token-cache access remain; see https://github.com/krustlet/oci-distribution/compare/main...vdice:oci-distribution:access-token-cache-rebased for a clarified view of the diff between this PR branch and krustlet/oci-distribution@main