### PR TITLE
chore(Cargo.toml): update jwt crate to get aud fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ chrono = { version = "0.4.23", features = ["serde"] }
 futures-util = "0.3"
 http = "1.1"
 http-auth = { version = "0.1", default_features = false }
-jwt = "0.16"
+# Fork incorporating needed fix not yet merged upstream:
+# https://github.com/mikkyang/rust-jwt/pull/86
+jwt = { git = "https://github.com/vdice/rust-jwt", rev = "c5b596d28a39dd428350b445d5c5829ba6352f02" }
 lazy_static = "1.4"
 olpc-cjson = "0.1"
 regex = "1.6"


### PR DESCRIPTION
The jwt library was failing to parse JWTs containing `aud` fields with array values (which is actually the [general, non-special case](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).  Incorporates [the upstream fix](https://github.com/mikkyang/rust-jwt/pull/86) via a fork, pending acceptance/merge to the main crate.

Revision is https://github.com/vdice/rust-jwt/commit/c5b596d28a39dd428350b445d5c5829ba6352f02

